### PR TITLE
[SEINT-732] More Hooks and SP Fix

### DIFF
--- a/extend-protection/admin/class-extend-protection-admin.php
+++ b/extend-protection/admin/class-extend-protection-admin.php
@@ -631,7 +631,7 @@ class Extend_Protection_Admin
 
     public function extend_sp_offer_location_callback()
     {
-        $extend_sp_offer_dropdown_values = array('woocommerce_review_order_before_shipping', 'woocommerce_review_order_after_shipping',
+        $extend_sp_offer_dropdown_values = array('woocommerce_before_checkout_billing_form', 'woocommerce_after_checkout_billing_form', 'woocommerce_review_order_before_shipping', 'woocommerce_review_order_after_shipping',
             'woocommerce_review_order_before_order_total', 'woocommerce_review_order_after_order_total', 'woocommerce_review_order_before_payment', 'woocommerce_review_order_before_submit');
 
         ?>

--- a/extend-protection/includes/class-extend-protection-shipping.php
+++ b/extend-protection/includes/class-extend-protection-shipping.php
@@ -103,7 +103,7 @@ class Extend_Protection_Shipping {
             $product = $cart_item['data'];
             if (!$product->is_virtual()) {
                 $items[] = array(
-                    'referenceId'   => $product->get_sku(),
+                    'referenceId'   => $product->get_id(),
                     'quantity'      => $cart_item['quantity'],
                     'purchasePrice' => ($product->get_price() * $cart_item['quantity'])*100,
                     'productName'   => $product->get_name(),


### PR DESCRIPTION
### class-extend-protection-admin.php

- Added two more hooks to the shipping protection settings:
  - `woocommerce_before_checkout_billing_form`
  - `woocommerce_after_checkout_billing_form`

### class-extend-protection-shipping.php
- SP Offers were not rendering because the `referenceId` was missing from the Ajax request.
 - Updated the `referenceId` from `get_sku()` to `get_id()` inside the `$items[]` array