### PR TITLE
[SEI-140] Removed extra function declaration.

### DIFF
--- a/extend-protection/admin/class-extend-protection-admin.php
+++ b/extend-protection/admin/class-extend-protection-admin.php
@@ -1022,8 +1022,4 @@ class Extend_Protection_Admin
         echo "<hr>";
     }
 
-    function extend_setting_catalog_sync_section_info() 
-    {
-        echo "<hr>";
-    }
 }


### PR DESCRIPTION
Small bug fix: function `extend_setting_catalog_sync_section_info` was being declared twice.