### PR TITLE
[SEINT-1727] Bugs found in QA

### DIFF
--- a/extend-protection/includes/class-extend-protection-cart-offer.php
+++ b/extend-protection/includes/class-extend-protection-cart-offer.php
@@ -189,7 +189,7 @@ class Extend_Protection_Cart_Offer {
         $extend_enable_cart_offers  = $this->settings['extend_enable_cart_offers'];
         $cart                       = WC()->cart;
 
-        if($enable_extend === '1') {
+        if($extend_enable_cart_offers === '1' && $enable_extend === '1') {
             wp_enqueue_script('extend_script');
             wp_enqueue_script('extend_cart_integration_script');
             $ajaxurl = admin_url( 'admin-ajax.php' );

--- a/extend-protection/includes/class-extend-protection-shipping.php
+++ b/extend-protection/includes/class-extend-protection-shipping.php
@@ -78,7 +78,7 @@ class Extend_Protection_Shipping {
                 $items[] = array(
                     'referenceId'   => $referenceId,
                     'quantity'      => $cart_item['quantity'],
-                    'purchasePrice' => ($product->get_price() * $cart_item['quantity'])*100,
+                    'purchasePrice' => ($product->get_price())*100,
                     'productName'   => $product->get_name(),
                 );
             }


### PR DESCRIPTION
### class-extend-protection-cart-offer.php
- Cart offers were showing when you updated the qty on the cart page
- Added `$extend_enable_cart_offers` in condition

### class-extend-protection-shipping.php
- The shipping quote was changed from 2% to 4% when the qty was increased to 2. 
- Removed `$cart_item['quantity'])` from `'purchasePrice'` index in ` $items[]` array.