### PR TITLE
[SOL-452] Extend SKU Update

### DIFF
--- a/extend-protection/includes/class-helloextend-global.php
+++ b/extend-protection/includes/class-helloextend-global.php
@@ -247,11 +247,10 @@ class HelloExtend_Protection_Global
         }
 
         $settings['sdk_url']             = 'https://sdk.helloextend.com/extend-sdk-client/v1/extend-sdk-client.min.js';
-        $settings['warranty_product_id'] = extend_product_protection_id();
-        /*
-        $settings['extend_use_skus']     = array_key_exists('extend_use_skus', $helloextend_protection_product_protection_settings)
-                                            ? $helloextend_protection_product_protection_settings['extend_use_skus'] : 0;
-        */
+
+        $settings['warranty_product_id'] = array_key_exists('warranty_product_id', $settings)
+            ? $settings['warranty_product_id'] : extend_product_protection_id();
+
         if (empty($settings['warranty_product_id'])) {
             HelloExtend_Protection_Logger::extend_log_error('Error: Warranty product is not created.');
         }

--- a/extend-protection/includes/class-helloextend-protection-activator.php
+++ b/extend-protection/includes/class-helloextend-protection-activator.php
@@ -28,7 +28,6 @@ class HelloExtend_Protection_Activator
      */
     public static function activate()
     {
-
         /* Extend  Logging : On activation create two fields in the wp_options table to store our errors, debugs and notices. */
         add_option('custom_error_log');
         add_option('custom_notice_log');
@@ -41,5 +40,57 @@ class HelloExtend_Protection_Activator
         add_option('extend_sandbox_token_date');
         add_option('extend_live_token');
         add_option('extend_sandbox_token');
+
+        //create the extend protection product if it doesn't exist (or if it's in the trash)
+        $extend_product_protection_id = extend_product_protection_id();
+        $deletedProduct = wc_get_product(extend_product_protection_id());
+
+        if (!$extend_product_protection_id || $deletedProduct->status == 'trash' ){
+            try {
+                // create new
+                $product = new WC_Product_Simple();
+                $product->set_name('Extend Product Protection');
+                $product->set_status('publish');
+                $product->set_sku(EXTEND_PRODUCT_PROTECTION_SKU);
+                $product->set_catalog_visibility('hidden');
+                $product->set_price(1.00);
+                $product->set_regular_price(1.00);
+                $product->set_virtual(true);
+                $product->save();
+            } catch (\Exception $e) {
+                HelloExtend_Protection_Logger::extend_log_error($e->getMessage());
+            }
+
+            // upload image and associate to product
+            try {
+                $product_id     = $product->get_id();
+                //check if image exists
+                if (file_exists(plugin_dir_path('images/Extend_icon.png'))) {
+
+                    $upload         = wc_rest_upload_image_from_url(plugins_url() . '/extend-protection/images/Extend_icon.png');
+                    if (is_wp_error($upload)) {
+                        HelloExtend_Protection_Logger::extend_log_error('Could not upload extend logo from ' . plugins_url() . '/extend-protection/images/Extend_icon.png : ' . $upload->get_error_message());
+                        return false;
+                    }
+
+                    $product_img_id = wc_rest_set_uploaded_image_as_attachment($upload, $product_id);
+                    if (is_wp_error($product_img_id)) {
+                        HelloExtend_Protection_Logger::extend_log_error('Could not retrieve product image id : ');
+                        return false;
+                    }
+
+                    //set the product image
+                    set_post_thumbnail($product_id, $product_img_id);
+                } else {
+                    HelloExtend_Protection_Logger::extend_log_error('Extend_icon file path incorrect: ' . plugin_dir_path('images/Extend_icon.png'));
+                }
+            } catch (\Exception $e) {
+                HelloExtend_Protection_Logger::extend_log_error($e->getMessage());
+            }
+        }else{
+            HelloExtend_Protection_Logger::extend_log_error('*** No need to create the product, it exists already');
+        }
+
+        return null;
     }
 }

--- a/extend-protection/includes/class-helloextend-protection-orders.php
+++ b/extend-protection/includes/class-helloextend-protection-orders.php
@@ -122,10 +122,12 @@ class HelloExtend_Protection_Orders
                 }
             }
 
+            // Get extend product id from settings
+            $extend_product_protection_id = $this->settings['warranty_product_id'];
+
             // Add relevant data to the line_items array
             // if product id for extend-product-protection, do not add it to extend_line_items array
-            // TODO: id = reference id = sku ?
-            if ($product_id != extend_product_protection_id()) {
+            if ($product_id != $extend_product_protection_id) {
                 $extend_line_items[] = array(
                     'lineItemTransactionId' => $product->get_id(),
                     'product'               => array(


### PR DESCRIPTION
The plugin class `HelloExtend_Protection_Activator`  now creates an Extend SKU when the plugin is activated. We updated the global settings to fetch the Extend SKU ID only if it doesn't exist in the `$settings` array.