### PR TITLE
Sol 460 ignore categories

### DIFF
--- a/helloextend-protection/admin/js/helloextend-protection-ignore-categories.js
+++ b/helloextend-protection/admin/js/helloextend-protection-ignore-categories.js
@@ -1,0 +1,12 @@
+(function( $ ) {
+    $(document).ready(($) => {
+        let isIgnored = $('input[name="helloextend-ignore-value"]').val() == 1;
+
+        if (isIgnored)
+            $('input#helloextend-ignore-display').attr("checked", isIgnored);
+
+        $('#helloextend-ignore-display').on('click', (e) => {
+            $('input[name="helloextend-ignore-value"]').attr('value', e.currentTarget.checked ? 1 : 0);
+        });
+    });
+})(jQuery);

--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -91,9 +91,9 @@ add_action('woocommerce_checkout_order_processed', 'helloextend_save_shipping_pr
 add_action('woocommerce_after_order_itemmeta', 'add_helloextend_protection_contract', 10, 2);
 
 // Hook into new category page
-add_action('product_cat_add_form_fields', 'add_helloextend_ignore_product_category_field', 10);
+add_action('product_cat_add_form_fields', 'helloextend_add_ignore_product_category_field', 10);
 // Hook into edit category page
-add_action('product_cat_edit_form_fields', 'edit_helloextend_ignore_product_category_field', 10);
+add_action('product_cat_edit_form_fields', 'helloextend_edit_ignore_product_category_field', 10);
 
 // Save when category is saved
 add_action('created_term', 'helloextend_save_category', 10, 1);
@@ -459,30 +459,31 @@ function add_helloextend_protection_contract($item_id, $item)
  * Adds "Ignore Category in Extend" field to the category create form
  * @return void
  */
-function add_helloextend_ignore_product_category_field( ) {
+function helloextend_add_ignore_product_category_field( ) {
+    // <script>
+    //     (($) => {
+    //         $(\'#helloextend-ignore-display\').on(\'click\', (e) => {
+    //             $(\'input[name="helloextend-ignore-value"]\').attr(\'value\', e.currentTarget.checked ? 1 : 0);
+    //         });
+    //     })(jQuery);
+    // </script>
     
     echo '
     <div class="form-field term-helloextend-category-ignore-wrap">
         <label for="helloextend-ignore-display">Ignore Category in Extend</label>
         <input id="helloextend-ignore-display" type="checkbox"/>
         <input hidden="true" name="helloextend-ignore-value" value="0"/>
-        <script>
-            (($) => {
-                $(\'#helloextend-ignore-display\').on(\'click\', (e) => {
-                    $(\'input[name="helloextend-ignore-value"]\').attr(\'value\', e.currentTarget.checked ? 1 : 0);
-                });
-            })(jQuery);
-        </script>
         <p id="helloextend-ignore-description">When enabled, this category will not be used to retrieve offers from Extend</p>
     </div>
     ';
+
 }
 
 /**
  * Adds "Ignore Category in Extend" field to category edit form
  * @return void
  */
-function edit_helloextend_ignore_product_category_field( ) {
+function helloextend_edit_ignore_product_category_field( ) {
     $term_id        = $_GET['tag_ID'];
 
     $ignored_categories = get_option('helloextend_protection_for_woocommerce_ignored_categories');
@@ -491,6 +492,16 @@ function edit_helloextend_ignore_product_category_field( ) {
         $is_ignored = 1;
     }
     
+    // <script>
+    //     (($) => {
+    //         let isIgnored = '. $is_ignored .';
+    //         $("#helloextend-ignore-display").attr(\'checked\', Boolean(isIgnored));
+    //         $(\'input[name="helloextend-ignore-value"]\').attr("value", isIgnored);
+    //         $("#helloextend-ignore-display").on(\'click\', (e) => {
+    //             $(\'input[name="helloextend-ignore-value"]\').attr("value", e.currentTarget.checked ? 1 : 0);
+    //         });
+    //     })(jQuery);
+    // </script>
     echo '
     <tr class="form-field form-required term-helloextend-ignore-wrap">
         <th scope="row">
@@ -498,21 +509,14 @@ function edit_helloextend_ignore_product_category_field( ) {
         </th>
         <td>
             <input id="helloextend-ignore-display" type="checkbox"/>
-            <input hidden="true" name="helloextend-ignore-value"/>
-            <script>
-                (($) => {
-                    let isIgnored = '. $is_ignored .';
-                    $("#helloextend-ignore-display").attr(\'checked\', Boolean(isIgnored));
-                    $(\'input[name="helloextend-ignore-value"]\').attr("value", isIgnored);
-                    $("#helloextend-ignore-display").on(\'click\', (e) => {
-                        $(\'input[name="helloextend-ignore-value"]\').attr("value", e.currentTarget.checked ? 1 : 0);
-                    });
-                })(jQuery);
-            </script>
+            <input hidden="true" name="helloextend-ignore-value" value="' . $is_ignored . '"/>
+            <script src=""></script>
             <p class="description" id="helloextend-ignore-description">When enabled, this category will not be used to retrieve offers from Extend</p>
         </td>
     </tr>
     ';
+    wp_enqueue_script('helloextend_set_ignore_value_script', plugin_dir_url(__FILE__) . 'admin/js/helloextend-protection-ignore-categories.js' , array('jquery'));
+
 }
 
 /**

--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -90,6 +90,14 @@ add_action('woocommerce_checkout_order_processed', 'helloextend_save_shipping_pr
 // Hook into WooCommerce order details display on admin screen
 add_action('woocommerce_after_order_itemmeta', 'add_helloextend_protection_contract', 10, 2);
 
+// Hook into new category page
+add_action('product_cat_add_form_fields', 'add_helloextend_ignore_product_category_field', 10);
+// Hook into edit category page
+add_action('product_cat_edit_form_fields', 'edit_helloextend_ignore_product_category_field', 10);
+
+// Save when category is saved
+add_action('created_term', 'helloextend_save_category', 10, 1);
+add_action('edited_term', 'helloextend_save_category', 10, 1);
 /* end add_action */
 
 
@@ -445,6 +453,98 @@ function add_helloextend_protection_contract($item_id, $item)
             }
         }
     }
+}
+
+/**
+ * Adds "Ignore Category in Extend" field to the category create form
+ * @return void
+ */
+function add_helloextend_ignore_product_category_field( ) {
+    
+    echo '
+    <div class="form-field term-helloextend-category-ignore-wrap">
+        <label for="helloextend-ignore-display">Ignore Category in Extend</label>
+        <input id="helloextend-ignore-display" type="checkbox"/>
+        <input hidden="true" name="helloextend-ignore-value" value="0"/>
+        <script>
+            (($) => {
+                $(\'#helloextend-ignore-display\').on(\'click\', (e) => {
+                    $(\'input[name="helloextend-ignore-value"]\').attr(\'value\', e.currentTarget.checked ? 1 : 0);
+                });
+            })(jQuery);
+        </script>
+        <p id="helloextend-ignore-description">When enabled, this category will not be used to retrieve offers from Extend</p>
+    </div>
+    ';
+}
+
+/**
+ * Adds "Ignore Category in Extend" field to category edit form
+ * @return void
+ */
+function edit_helloextend_ignore_product_category_field( ) {
+    $term_id        = $_GET['tag_ID'];
+
+    $ignored_categories = get_option('helloextend_protection_for_woocommerce_ignored_categories');
+    $is_ignored = 0;
+    if ($ignored_categories && array_search($term_id, $ignored_categories) > -1) {
+        $is_ignored = 1;
+    }
+    
+    echo '
+    <tr class="form-field form-required term-helloextend-ignore-wrap">
+        <th scope="row">
+            <label for="helloextend-ignore-display">Ignore Category in Extend</label>
+        </th>
+        <td>
+            <input id="helloextend-ignore-display" type="checkbox"/>
+            <input hidden="true" name="helloextend-ignore-value"/>
+            <script>
+                (($) => {
+                    let isIgnored = '. $is_ignored .';
+                    $("#helloextend-ignore-display").attr(\'checked\', Boolean(isIgnored));
+                    $(\'input[name="helloextend-ignore-value"]\').attr("value", isIgnored);
+                    $("#helloextend-ignore-display").on(\'click\', (e) => {
+                        $(\'input[name="helloextend-ignore-value"]\').attr("value", e.currentTarget.checked ? 1 : 0);
+                    });
+                })(jQuery);
+            </script>
+            <p class="description" id="helloextend-ignore-description">When enabled, this category will not be used to retrieve offers from Extend</p>
+        </td>
+    </tr>
+    ';
+}
+
+/**
+ * Save the ignored category to DB
+ * @param int $term_id ID of the ignored category
+ * @return void
+ */
+function helloextend_save_category($term_id) {
+    $helloextend_ignore = (bool) $_POST['helloextend-ignore-value'];
+    
+    $ignored_categories = get_option('helloextend_protection_for_woocommerce_ignored_categories');
+    if (!$ignored_categories) {
+        $ignored_categories = array();
+    }
+
+    $category_in_array = in_array($term_id, $ignored_categories);
+
+    if (($helloextend_ignore && $category_in_array) || (!$helloextend_ignore && !$category_in_array)) {
+        return;
+    } else if (!$helloextend_ignore && $category_in_array) {
+        $new_ignored_categories = array();
+        foreach ($ignored_categories as $category_id) { 
+            if ($category_id !== $term_id) {
+                array_push($new_ignored_categories, $ignored_categories[$i]);
+            }
+        }
+        $ignored_categories = $new_ignored_categories;
+    } else if ($helloextend_ignore && !$category_in_array) {
+        array_push($ignored_categories, $term_id);
+    }
+
+    update_option('helloextend_protection_for_woocommerce_ignored_categories', $ignored_categories);
 }
 
 helloextend_run();

--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -498,4 +498,31 @@ class HelloExtend_Protection_Global
         }
         return $token;
     }
+
+        /**
+     * Gets the first category that isn't ignored
+     * @param array $categories Categories attached to the product
+     * @param array $ignored_categories Categories marked as ignored in admin
+     * @return string The category name
+     * 
+     * @since 1.0.0
+     */
+    public static function get_first_valid_category($categories): string {
+        $ignored_categories = (array) get_option('helloextend_protection_for_woocommerce_ignored_categories');
+
+        // If ignored categories doesn't exist or is empty, return first category
+        if (is_null($ignored_categories) || count($ignored_categories) == 0) {
+            return $categories[0]->name;
+        }
+
+        // Find the first category that is not ignored and return it
+        foreach ($categories as $category) {
+            if (!in_array($category->term_id, $ignored_categories)) {
+                return $category->name;
+            }
+        }
+
+        // If all categories are ignored, return the first one in the array
+        return $categories[0]->name;
+    }
 }

--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -507,7 +507,7 @@ class HelloExtend_Protection_Global
      * 
      * @since 1.0.0
      */
-    public static function get_first_valid_category($categories): string {
+    public static function helloextend_get_first_valid_category($categories): string {
         $ignored_categories = (array) get_option('helloextend_protection_for_woocommerce_ignored_categories');
 
         // If ignored categories doesn't exist or is empty, return first category

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -194,7 +194,7 @@ class HelloExtend_Protection_Cart_Offer
             $item_sku    = $cart_item['data']->get_sku() ? $cart_item['data']->get_sku() : $item_id;
             $referenceId = $this->settings['helloextend_use_skus'] ? $item_sku : $item_id;
             $categories  = get_the_terms($item_id, 'product_cat');
-            $category    = $categories[0]->name;
+            $category    = HelloExtend_Protection_Global::get_first_valid_category($categories);
 
             echo "<div id='offer_".esc_attr($item_id)."' class='cart-extend-offer' data-covered='".esc_attr($referenceId)."' data-category='".esc_attr($category)."'></div>";
         }

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -194,7 +194,7 @@ class HelloExtend_Protection_Cart_Offer
             $item_sku    = $cart_item['data']->get_sku() ? $cart_item['data']->get_sku() : $item_id;
             $referenceId = $this->settings['helloextend_use_skus'] ? $item_sku : $item_id;
             $categories  = get_the_terms($item_id, 'product_cat');
-            $category    = HelloExtend_Protection_Global::get_first_valid_category($categories);
+            $category    = HelloExtend_Protection_Global::helloextend_get_first_valid_category($categories);
 
             echo "<div id='offer_".esc_attr($item_id)."' class='cart-extend-offer' data-covered='".esc_attr($referenceId)."' data-category='".esc_attr($category)."'></div>";
         }

--- a/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
@@ -92,7 +92,7 @@ class HelloExtend_Protection_PDP_Offer
         $sku                         = $product->get_sku();
         
         $categories                  = get_the_terms($id, 'product_cat');
-        $first_category              = HelloExtend_Protection_Global::get_first_valid_category($categories);
+        $first_category              = HelloExtend_Protection_Global::helloextend_get_first_valid_category($categories);
 
         $price                       = (int) floatval($product->get_price() * 100);
         $type                        = $product->get_type();

--- a/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
@@ -90,8 +90,10 @@ class HelloExtend_Protection_PDP_Offer
         $helloextend_use_skus             = $this->settings['helloextend_use_skus'];
         $id                          = $product->get_id();
         $sku                         = $product->get_sku();
+        
         $categories                  = get_the_terms($id, 'product_cat');
-        $first_category              = $categories[0]->name;
+        $first_category              = HelloExtend_Protection_Global::get_first_valid_category($categories);
+
         $price                       = (int) floatval($product->get_price() * 100);
         $type                        = $product->get_type();
         $env                         = $this->settings['helloextend_environment'];


### PR DESCRIPTION
Added option to category creation and editing to ignore a category in Extend offers. Added logic to offer script to use the first "good" category found.

This pull request will create a new entry in the `wp_options` table called `helloextend_protection_for_woocommerce_ignored_categories`that contains an array of `term_id` for ignored categories.