### PR TITLE
Update class-helloextend-protection-orders.php

### DIFF
--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -561,17 +561,18 @@ function helloextend_add_protection_contract($item_id, $item)
         // Get product object
         if (method_exists($item, 'get_product')) {
             $product = $item->get_product();
+            if ( $product && $product instanceof WC_Product ) {
+                // Check if the product SKU matches product protection
+                if ($product->get_sku() === 'helloextend-product-protection') {
+                  echo '<table cellspacing="0" class="display_meta"><tbody><tr><th>Extend Product Protection contracts : </th><th></th></tr>';
 
-            // Check if the product SKU matches product protection
-            if ($product->get_sku() === 'helloextend-product-protection') {
-                echo '<table cellspacing="0" class="display_meta"><tbody><tr><th>Extend Product Protection contracts : </th><th></th></tr>';
-
-                foreach ($contracts as $product_covered => $contract_id) {
-                    if ($helloextend_meta_data['covered_product_id'] == $product_covered) {
-                        echo '<tr><td><a href="' . esc_url($url . '?contractId=' . $contract_id . '&accessToken=' . $token) . '">' . esc_html($contract_id) . '</a></td></tr>';
+                    foreach ($contracts as $product_covered => $contract_id) {
+                        if ($helloextend_meta_data['covered_product_id'] == $product_covered) {
+                            echo '<tr><td><a href="' . esc_url($url . '?contractId=' . $contract_id . '&accessToken=' . $token) . '">' . esc_html($contract_id) . '</a></td></tr>';
+                        }
                     }
+                        echo '</tbody></table>';
                 }
-                echo '</tbody></table>';
             }
         }
     }

--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -563,15 +563,22 @@ function helloextend_add_protection_contract($item_id, $item)
             $product = $item->get_product();
             if ( $product && $product instanceof WC_Product ) {
                 // Check if the product SKU matches product protection
-                if ($product->get_sku() === 'helloextend-product-protection') {
+                if ($product->get_sku() === HELLOEXTEND_PRODUCT_PROTECTION_SKU) {
                   echo '<table cellspacing="0" class="display_meta"><tbody><tr><th>Extend Product Protection contracts : </th><th></th></tr>';
 
                     foreach ($contracts as $product_covered => $contract_id) {
-                        if ($helloextend_meta_data['covered_product_id'] == $product_covered) {
-                            echo '<tr><td><a href="' . esc_url($url . '?contractId=' . $contract_id . '&accessToken=' . $token) . '">' . esc_html($contract_id) . '</a></td></tr>';
+                        if ( isset( $helloextend_meta_data['covered_product_id'] ) && $helloextend_meta_data['covered_product_id'] == $product_covered ) {
+                            $link = add_query_arg(
+                                array(
+                                    'contractId'  => rawurlencode( $contract_id ),
+                                    'accessToken' => rawurlencode( $token ),
+                                    ),
+                                $url
+                                );
+                            echo '<tr><td><a href="' . esc_url( $link ) . '">' . esc_html( $contract_id ) . '</a></td></tr>';
                         }
                     }
-                        echo '</tbody></table>';
+                    echo '</tbody></table>';
                 }
             }
         }

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -359,7 +359,11 @@ class HelloExtend_Protection_Orders
 			),
 		);
 
-        $response = wp_remote_request($this->settings['api_host'] . '/orders/search?transactionId='.$order->get_id(), $request_args);
+		$endpoint = add_query_arg(
+			array( 'transactionId' => rawurlencode( (string) $order->get_id() ) ),
+			$this->settings['api_host'] . '/orders/search'
+		);
+		$response = wp_remote_request( $endpoint, $request_args );
 		if (is_wp_error($response)) {
 			$error_message = $response->get_error_message();
 			HelloExtend_Protection_Logger::helloextend_log_error(' Order ID ' . $order->get_id() . ' : GET request failed: ' . $error_message.', cannot cancel extend order');

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -328,12 +328,13 @@ class HelloExtend_Protection_Orders
 	 * @param string $order_id The ID of the order.
 	 * @since 1.0.0
 	 */
-	public function cancel_order(string $order_id, array $order = null)
+	// Accept a WC_Order object or null.
+	// Using `mixed` keeps compatibility with PHP <8 (no union types).
+	public function cancel_order(string $order_id, $order = null) /* @param WC_Order|null $order */
 	{
 		if ($order === null) {
 			$order = wc_get_order($order_id);
 		}
-
 		// Get Token from Global function
 		$token = HelloExtend_Protection_Global::helloextend_get_token();
 

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -408,11 +408,16 @@ class HelloExtend_Protection_Orders
 							$cancel_response_code . ')'
 						);
 					}
-				}
+				}else{
+                    return;
+                }
+
 			} else {
 				HelloExtend_Protection_Logger::helloextend_log_error(
 					'Order ID ' . $order->get_id() . ' : GET request returned status ' . $response_code
 				);
-			}
-	}
+                return;
+            }
+        }
+    }
 }

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -359,10 +359,10 @@ class HelloExtend_Protection_Orders
 			),
 		);
 
-		$endpoint = add_query_arg(
-			array( 'transactionId' => rawurlencode( (string) $order->get_id() ) ),
-			$this->settings['api_host'] . '/orders/search'
-		);
+        $endpoint = add_query_arg(
+            array( 'transactionId' => (string) $order->get_id() ),
+            $this->settings['api_host'] . '/orders/search'
+        );
 		$response = wp_remote_request( $endpoint, $request_args );
 		if (is_wp_error($response)) {
 			$error_message = $response->get_error_message();

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -371,11 +371,13 @@ class HelloExtend_Protection_Orders
 			$response_code = wp_remote_retrieve_response_code( $response ); //200 is good
 			if ($response_code==200){
 				// if GET was successful retrieve the response and find order uuid
-				$data      = json_decode(wp_remote_retrieve_body($response));
-				if ($data){
-					$extend_order_uuid = $data->orders[0]->id ?: null ;
-					if($extend_order_uuid){
-						//HelloExtend_Protection_Logger::helloextend_log_error('Order  ID ' . $order->get_id() . ' : Cancelling extend order: '.$extend_order_uuid);
+				$data = json_decode( wp_remote_retrieve_body( $response ) );
+				$extend_order_uuid = null;
+				if ( isset( $data->orders ) && is_array( $data->orders ) && ! empty( $data->orders[0]->id ) ) {
+					$extend_order_uuid = $data->orders[0]->id;
+				}
+				if ( $extend_order_uuid ) {
+					//HelloExtend_Protection_Logger::helloextend_log_error('Order  ID ' . $order->get_id() . ' : Cancelling extend order: ' . $extend_order_uuid);
 
 						//POST cancel the order (uuid)
 						//{{API_HOST}}/orders/{{orderId}}/cancel

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -332,9 +332,15 @@ class HelloExtend_Protection_Orders
 	// Using `mixed` keeps compatibility with PHP <8 (no union types).
 	public function cancel_order(string $order_id, $order = null) /* @param WC_Order|null $order */
 	{
-		if ($order === null) {
-			$order = wc_get_order($order_id);
-		}
+        $order = wc_get_order($order_id);
+
+        if ( ! $order instanceof WC_Order ) {
+                HelloExtend_Protection_Logger::helloextend_log_error(
+                    'Cannot cancel Extend order – WooCommerce order ' . $order_id . ' not found.'
+                );
+                return;
+            }
+
 		// Get Token from Global function
 		$token = HelloExtend_Protection_Global::helloextend_get_token();
 


### PR DESCRIPTION
added the cancellation of orders, on the extend side it cancels associated contracts as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Orders cancelled in WooCommerce will now automatically trigger cancellation of the corresponding contract in the Extend system.
- **Bug Fixes**
  - Improved product validation to ensure protection contracts display correctly only for valid products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->