### PR TITLE
Fixed SP issue. Removed references to Extend as SKU setting

### DIFF
--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -116,8 +116,7 @@ class HelloExtend_Protection_Global
             $_woo_product = wc_get_product($cart_item['product_id']);
 
             // retrieve id or sku based on settings, and default to id if sku is empty
-            $sku         = $_woo_product->get_sku() <> '' ? $_woo_product->get_sku() : $cart_item['product_id'];
-            $referenceId = $settings['helloextend_use_skus'] ? $sku : $cart_item['product_id'];
+            $referenceId = $cart_item['product_id'];
 
             // add sku to cart item and label it referenceId
             $cart[$cart_item_key]['referenceId']  = $referenceId;

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -192,7 +192,7 @@ class HelloExtend_Protection_Cart_Offer
         if (! isset($cart_item['extendData']) ) {
             $item_id     = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
             $item_sku    = $cart_item['data']->get_sku() ? $cart_item['data']->get_sku() : $item_id;
-            $referenceId = $this->settings['helloextend_use_skus'] ? $item_sku : $item_id;
+            $referenceId = $item_id;
             $categories  = get_the_terms($item_id, 'product_cat');
             $category    = HelloExtend_Protection_Global::helloextend_get_first_valid_category($categories);
 

--- a/helloextend-protection/includes/class-helloextend-protection-logger.php
+++ b/helloextend-protection/includes/class-helloextend-protection-logger.php
@@ -563,8 +563,8 @@ class HelloExtend_Protection_Logger
 
     public static function helloextend_logger_ajax_call()
     {
-        $method = isset($_POST['method']) ? wp_unslash(sanitize_text_field($_POST['method'])) : null;
-        $message = isset($_POST['message']) ? wp_unslash(sanitize_text_field($_POST['message'])) : null;
+        $method = isset($_POST['method']) ? sanitize_text_field(wp_unslash($_POST['method'])) : null;
+        $message = isset($_POST['message']) ? sanitize_text_field(wp_unslash($_POST['message'])) : null;
 
         if ( $method == 'notice' ) {
             self::helloextend_log_notice($message);

--- a/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
@@ -87,7 +87,6 @@ class HelloExtend_Protection_PDP_Offer
         global $product;
 
         // Variables that are passed to the PDP JS Script
-        $helloextend_use_skus             = $this->settings['helloextend_use_skus'];
         $id                          = $product->get_id();
         $sku                         = $product->get_sku();
         
@@ -108,7 +107,7 @@ class HelloExtend_Protection_PDP_Offer
             wp_localize_script(
                 'helloextend_product_integration_script',
                 'ExtendProductIntegration',
-                compact('id', 'sku', 'first_category', 'price', 'type', 'env', 'helloextend_enabled', 'helloextend_pdp_offers_enabled', 'helloextend_modal_offers_enabled', 'helloextend_use_skus', 'atc_button_selector')
+                compact('id', 'sku', 'first_category', 'price', 'type', 'env', 'helloextend_enabled', 'helloextend_pdp_offers_enabled', 'helloextend_modal_offers_enabled', 'atc_button_selector')
             );
             echo "<div class='helloextend-offer' data-extend='pdpOfferContainer' style='width: 100%;'></div>";
         }

--- a/helloextend-protection/includes/class-helloextend-protection-shipping.php
+++ b/helloextend-protection/includes/class-helloextend-protection-shipping.php
@@ -117,7 +117,7 @@ class HelloExtend_Protection_Shipping
         foreach ( $cart_items as $cart_item_key => $cart_item ) {
             $product = $cart_item['data'];
             if (! $product->is_virtual() ) {
-                $referenceId = ( $this->settings['helloextend_use_skus'] == 1 ) ? $product->get_sku() : $product->get_id();
+                $referenceId = $product->get_id();
                 $items[]     = array(
                  'referenceId'   => $referenceId,
                  'quantity'      => $cart_item['quantity'],

--- a/helloextend-protection/js/helloextend-cart-offers.js
+++ b/helloextend-protection/js/helloextend-cart-offers.js
@@ -88,7 +88,9 @@
     }
     
     // Wait until the document is fully loaded before running the script.
-    $(document).ready(initCartOffers);
+    $(document).ready(() => {
+        initCartOffers();
+    });
     
     // When the cart totals are updated, re-render the Extend offers.
     $(document.body).on('updated_cart_totals', function () {

--- a/helloextend-protection/js/helloextend-pdp-offers.js
+++ b/helloextend-protection/js/helloextend-pdp-offers.js
@@ -5,25 +5,19 @@
         if (!ExtendWooCommerce || !ExtendProductIntegration) return;
 
         // Deconstructs ExtendProductIntegration variables
-        const { type: product_type, id: product_id, sku, first_category, price, helloextend_pdp_offers_enabled, helloextend_modal_offers_enabled, helloextend_use_skus, atc_button_selector } = ExtendProductIntegration;
+        const { type: product_type, id: product_id, sku, first_category, price, helloextend_pdp_offers_enabled, helloextend_modal_offers_enabled, atc_button_selector } = ExtendProductIntegration;
 
         const $atcButton = jQuery(atc_button_selector)
 
         const quantity = parseInt(document.querySelector('input[name="quantity"]').value || 1)
 
         let supportedProductType = true;
-        let reference_id = '';
+        let reference_id = product_id;
 
         // If PDP offers are not enabled, hide Extend offer div
         if (helloextend_pdp_offers_enabled === '0') {
             const extendOffer = document.querySelector('.helloextend-offer')
             extendOffer.style.display = 'none';
-        }
-
-        if (helloextend_use_skus == '1') {
-            reference_id = sku;
-        } else {
-            reference_id = product_id;
         }
 
         function handleAddToCartLogic(variation_id)  {

--- a/helloextend-protection/js/helloextend-shipping-offers.js
+++ b/helloextend-protection/js/helloextend-shipping-offers.js
@@ -9,7 +9,7 @@
             function initShippingOffers()
             {
                 // Deconstructs ExtendProductIntegration variables
-                const { env, items, enable_helloextend_sp, ajax_url, update_order_review_nonce } = ExtendShippingIntegration;
+                const { env, items, enable_helloextend_sp, ajax_url, update_order_review_nonce, helloextend_sp_add_sku } = ExtendShippingIntegration;
                 let items_array = eval(items);
 
                 // If Extend shipping protection offers are not enabled, hide Extend offer div
@@ -44,6 +44,13 @@
                                         },
                                         success: function () {
                                             $('body').trigger('update_checkout');
+
+                                            // Need to trigger again for SP line item settings to get correct total
+                                            if (helloextend_sp_add_sku) {
+                                                setTimeout(() => {
+                                                    $('body').trigger('update_checkout');
+                                                }, 50);
+                                            }
                                         }
                                     }
                                 );
@@ -59,6 +66,13 @@
                                         },
                                         success: function () {
                                             $('body').trigger('update_checkout');
+
+                                            // Need to trigger again for SP line item settings to get correct total
+                                            if (helloextend_sp_add_sku) {
+                                                setTimeout(() => {
+                                                    $('body').trigger('update_checkout');
+                                                }, 50);
+                                            }
                                         }
                                     }
                                 );
@@ -78,6 +92,13 @@
                                         },
                                         success: function () {
                                             $('body').trigger('update_checkout');
+
+                                            // Need to trigger again for SP line item settings to get correct total
+                                            if (helloextend_sp_add_sku) {
+                                                setTimeout(() => {
+                                                    $('body').trigger('update_checkout');
+                                                }, 50);
+                                            }
                                         }
                                     }
                                 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logic throughout the app to always use the product ID as the reference ID, removing conditional checks and settings related to SKUs.
  * Cleaned up variables and removed unused settings from both backend and frontend code.

* **Bug Fixes**
  * Improved input sanitization order for certain AJAX calls to enhance data handling.

* **New Features**
  * Shipping protection now triggers an additional checkout update when a specific flag is enabled, ensuring totals are accurately recalculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->