### PR TITLE
Update class-helloextend-protection-orders.php

### DIFF
--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -175,6 +175,12 @@ class HelloExtend_Protection_Orders
             $order = wc_get_order($order_id);
         }
         $order_data = $order->get_data();
+        $items = $order->get_items();
+        $product_id_array = array();
+        foreach($items as $item){
+            $product_id_array[] = $item->get_product_id();
+        }
+        $product_id_list = implode(',', $product_id_array);
 
         // if contract creation is set to order create, call helloextend_get_plans_and_products
         $contract_creation_event = $this->settings['helloextend_product_protection_contract_create_event'];
@@ -200,14 +206,58 @@ class HelloExtend_Protection_Orders
         // check if shipping protection meta exists
         if ($shipping_protection_quote_id) {
 	        // phpcs:disable WordPress.PHP.DevelopmentFunctions
-	        HelloExtend_Protection_Logger::helloextend_log_notice('Shipping Protection Meta Exists: ' . print_r($shipping_protection_quote_id, true));
+            if ($this->settings['enable_helloextend_debug'] == 1) {
+                HelloExtend_Protection_Logger::helloextend_log_debug('Shipping Protection Meta Exists: ' . print_r($shipping_protection_quote_id, true));
+            }
 	        // phpcs:enable
 
+            // on order completion send shipmentInfo to activate the contract, otherwise send an empty array to create the contract
+            $shipmentInfo = array();
+            $store_raw_country = get_option('woocommerce_default_country');
+            $split_country = explode(":", $store_raw_country);
+            $store_country = $split_country[0];
+            $store_state = $split_country[1];
+            $called_action_hook = current_filter();
+            if ($called_action_hook == 'woocommerce_order_status_completed') {
+                $arg = array(
+                    'limit'  => -1,
+                    'status' => 'publish',
+                    'return' => 'ids'
+                );
+                $shipmentInfo[] = array(
+                    "shipmentDate" => time(),
+                    "shippingProvider" => "custom",
+                    "trackingId" => "woocommerce-shipping",
+                    "productIds" => $product_id_list,
+                    "destination" => array(
+                        "address1" => $order_data['shipping']['address_1'],
+                        "address2" => $order_data['shipping']['address_2'] ? $order_data['shipping']['address_2'] : null,
+                        "city" => $order_data['shipping']['country'],
+                        "companyName" => '',
+                        "countryCode" => $order_data['shipping']['country'],
+                        "personName" => $order_data['shipping']['first_name'] . ' ' . $order_data['shipping']['last_name'],
+                        "phone" => $order_data['shipping']['phone'] ? $order_data['shipping']['phone'] : null,
+                        "postalCode" => $order_data['shipping']['postcode'],
+                        "provinceCode" => $order_data['shipping']['state']
+                    ),
+                    "source" => array(
+                        "address1" => get_option('woocommerce_store_address'),
+                        "address2" => get_option('woocommerce_store_address_2'),
+                        "city" => get_option('woocommerce_store_city'),
+                        "companyName" => '',
+                        "countryCode" => $store_country,
+                        "personName" => '',
+                        "phone" => get_option('woocommerce_store_phone'),
+                        "postalCode" =>get_option('woocommerce_store_postcode'),
+                        "provinceCode" => $store_state
+                    )
+                );
+            }
             // Push shipping protection line item into helloextend_line_items array
             $helloextend_line_items[] = array(
                 'lineItemTransactionId' => $order_id . '-shipping',
                 'quoteId'               => $shipping_protection_quote_id,
-                'shipmentInfo'          => array(),
+                'shipmentInfo'          => $shipmentInfo,
             );
         } else {
             if ($this->settings['enable_helloextend_debug'] == 1) {

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -207,7 +207,9 @@ class HelloExtend_Protection_Orders
         if ($shipping_protection_quote_id) {
 	        // phpcs:disable WordPress.PHP.DevelopmentFunctions
             if ($this->settings['enable_helloextend_debug'] == 1) {
-                HelloExtend_Protection_Logger::helloextend_log_debug('Shipping Protection Meta Exists: ' . print_r($shipping_protection_quote_id, true));
+                HelloExtend_Protection_Logger::helloextend_log_debug(
+                    'Shipping Protection Meta Exists: ' . (string) $shipping_protection_quote_id
+                );
             }
 	        // phpcs:enable
 

--- a/helloextend-protection/includes/class-helloextend-protection-orders.php
+++ b/helloextend-protection/includes/class-helloextend-protection-orders.php
@@ -232,11 +232,11 @@ class HelloExtend_Protection_Orders
                     "destination" => array(
                         "address1" => $order_data['shipping']['address_1'],
                         "address2" => $order_data['shipping']['address_2'] ? $order_data['shipping']['address_2'] : null,
-                        "city" => $order_data['shipping']['country'],
+                        "city" => $order_data['shipping']['city'],
                         "companyName" => '',
                         "countryCode" => $order_data['shipping']['country'],
                         "personName" => $order_data['shipping']['first_name'] . ' ' . $order_data['shipping']['last_name'],
-                        "phone" => $order_data['shipping']['phone'] ? $order_data['shipping']['phone'] : null,
+                        "phone" => '',
                         "postalCode" => $order_data['shipping']['postcode'],
                         "provinceCode" => $order_data['shipping']['state']
                     ),


### PR DESCRIPTION
bring shipmentInfo array in contract when order is completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shipping Protection line items now include comprehensive shipment details once an order is completed: shipment date, carrier, tracking ID, associated product IDs, and destination/source addresses for clearer post-purchase tracking.

- **Bug Fixes**
  - Shipping protection items no longer appear empty on completed orders; they now populate with the assembled shipment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->