### PR TITLE
minicart offers for woocommerce

### DIFF
--- a/helloextend-protection/admin/class-helloextend-protection-admin.php
+++ b/helloextend-protection/admin/class-helloextend-protection-admin.php
@@ -160,8 +160,8 @@ class HelloExtend_Protection_Admin
         $ajaxurl           = admin_url('admin-ajax.php');
         $nonce             = wp_create_nonce('helloextend_sync_nonce');
         $helloextend_sync_batch = $this->helloextend_protection_for_woocommerce_settings_catalog_sync_options['helloextend_sync_batch'];
-        $debug_log_enabled = $this->helloextend_protection_for_woocommerce_settings_general_options['enable_helloextend_debug'];
-	    $log_enabled = $this->helloextend_protection_for_woocommerce_settings_general_options['enable_helloextend_log'];
+        $debug_log_enabled = $this->helloextend_protection_for_woocommerce_settings_general_options['enable_helloextend_debug'] ?? '';
+	    $log_enabled = $this->helloextend_protection_for_woocommerce_settings_general_options['enable_helloextend_log'] ?? '';
 
 
 	    wp_enqueue_script('helloextend_script');

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -307,7 +307,7 @@ class HelloExtend_Protection_Cart_Offer
                 'categories'      => $categories, 
                 'top_category'    => $category,               // array e.g. ['T-shirts', 'Summer']
                 'quantity'        => $cart_item['quantity'],
-                'price_raw'       => $product->get_price(),          // string: "29.99"
+                'price_raw'       => (int) round( (float) $product->get_price() * 100 ),         // string: "29.99"
                 'price_formatted' => wc_price( $product->get_price() ), // "$29.99" or with currency
                 'price_html'      => $product->get_price_html(),     // includes <del>/<ins> if on sale
                 'line_subtotal'   => WC()->cart->get_product_subtotal( $product, $cart_item['quantity'] ),

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -294,7 +294,7 @@ class HelloExtend_Protection_Cart_Offer
 
 
             foreach( $categories as $cat => $term ){
-                    if (!isset($ignored[(int)($cat ?? 0)])) {
+                    if (!isset($ignored_set[(int)($cat)])) {
                         $category = $term  ?? 'Uncategorized';
                         break;
                     }

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -75,6 +75,11 @@ class HelloExtend_Protection_Cart_Offer
         //minicart
         add_action('wp_enqueue_scripts', [$this, 'minicart_offers']);
 
+        // minicart normalization
+        add_action('woocommerce_cart_item_removed', [ $this, 'normalize_cart' ]);
+        add_action('woocommerce_after_cart_item_quantity_update', [ $this, 'normalize_cart' ]);
+        add_action('woocommerce_add_to_cart', [ $this, 'normalize_cart' ]);
+         
     }
 
     private function is_item_helloextend($item)
@@ -107,33 +112,33 @@ class HelloExtend_Protection_Cart_Offer
         $cart_contents = WC()->cart->get_cart_contents();
 
         $products = array();
+        if ($cart_contents){
+            foreach ( $cart_contents as $line ) {
 
-        foreach ( $cart_contents as $line ) {
+                $product_id = $this->get_product_id($line);
+                $id = $line['extendData']['leadToken'] ?? $product_id;
 
-            $product_id = $this->get_product_id($line);
-            $id = $line['extendData']['leadToken'] ?? $product_id;
+                $product = $products[ $id ] ?? array(
+                    'quantity'          => 0,
+                    'warranty_quantity' => 0,
+                    'warranties'        => array(),
+                );
 
-            $product = $products[ $id ] ?? array(
-                'quantity'          => 0,
-                'warranty_quantity' => 0,
-                'warranties'        => array(),
-            );
+                if ($this->is_warranty($line)) {
+                    $product['warranty_quantity'] += $line['quantity'];
+                    $product['warranties'][] = $line;
+                } else {
+                    $product['quantity'] += $line['quantity'];
 
-            if ($this->is_warranty($line)) {
-                $product['warranty_quantity'] += $line['quantity'];
-                $product['warranties'][] = $line;
-            } else {
-                $product['quantity'] += $line['quantity'];
-
-                if (isset($line['extendData']) && isset($line['extendData']['leadQuantity'])) {
-                    $product['leadQuantity'] = $line['extendData']['leadQuantity'];
-                    $product['leadProductKey'] = $line['key'];
+                    if (isset($line['extendData']) && isset($line['extendData']['leadQuantity'])) {
+                        $product['leadQuantity'] = $line['extendData']['leadQuantity'];
+                        $product['leadProductKey'] = $line['key'];
+                    }
                 }
+
+                $products[ $id ] = $product;
             }
-
-            $products[ $id ] = $product;
         }
-
         return $products;
     }
 
@@ -259,6 +264,7 @@ class HelloExtend_Protection_Cart_Offer
 
     // renders minicart offers
     public function minicart_offers(){
+        $cart_contents = null;
         // get Extend options
         $enable_helloextend             = trim($this->settings['enable_helloextend']);
         $helloextend_enable_cart_offers = $this->settings['helloextend_enable_cart_offers'];
@@ -318,7 +324,7 @@ class HelloExtend_Protection_Cart_Offer
 
         }
 
-        if ($helloextend_enable_cart_offers === '1' && $enable_helloextend === '1' ) {
+        if ($helloextend_enable_cart_offers === '1' && $enable_helloextend === '1' && $cart_contents) {
             wp_enqueue_script('helloextend_minicart_integration_script');
              wp_localize_script(
                 'helloextend_minicart_integration_script',

--- a/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-cart-offer.php
@@ -72,6 +72,9 @@ class HelloExtend_Protection_Cart_Offer
         // run normalization on check
         add_action('woocommerce_check_cart_items', [ $this, 'normalize_cart' ]);
 
+        //minicart
+        add_action('wp_enqueue_scripts', [$this, 'minicart_offers']);
+
     }
 
     private function is_item_helloextend($item)
@@ -241,9 +244,11 @@ class HelloExtend_Protection_Cart_Offer
         if ($helloextend_enable_cart_offers === '1' && $enable_helloextend === '1' ) {
             wp_enqueue_script('helloextend_script');
             wp_enqueue_script('helloextend_cart_integration_script');
+            wp_enqueue_script('helloextend_minicart_integration_script');
             $ajaxurl = admin_url('admin-ajax.php');
             wp_localize_script(
                 'helloextend_cart_integration_script',
+                //'helloextend_minicart_integration_script',
                 'ExtendCartIntegration',
                 compact('cart', 'helloextend_enable_cart_offers')
             );
@@ -251,4 +256,78 @@ class HelloExtend_Protection_Cart_Offer
             HelloExtend_Protection_Logger::helloextend_log_error('Cart Offers Class: Extend is not enabled');
         }
     }
+
+    // renders minicart offers
+    public function minicart_offers(){
+        // get Extend options
+        $enable_helloextend             = trim($this->settings['enable_helloextend']);
+        $helloextend_enable_cart_offers = $this->settings['helloextend_enable_cart_offers'];
+        $minicart                           = WC()->cart;
+
+        foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+           /** @var WC_Product $product */
+            $product = $cart_item['data'];
+
+            // Skip if product object is invalid (rare, but safe)
+            if ( ! is_a( $product, 'WC_Product' ) ) {
+                continue;
+            }
+
+            $product_id = $product->get_id(); 
+            // Categories: array of category names
+            $categories = array();
+            $terms = get_the_terms( $product_id, 'product_cat' );
+            if ( $terms && ! is_wp_error( $terms ) ) {
+                  $categories = wp_list_pluck( $terms, 'name', 'term_id' ); // ← use 'slug' or 'term_id' if preferred
+                
+            }
+
+            $category = null;
+       
+            $ignored_set = array_flip(array_map('intval', (array) get_option('helloextend_protection_for_woocommerce_ignored_categories')));
+
+
+            foreach( $categories as $cat => $term ){
+                    if (!isset($ignored[(int)($cat ?? 0)])) {
+                        $category = $term  ?? 'Uncategorized';
+                        break;
+                    }
+            }
+            // Build item data
+            $item = array(
+               
+                'product_id'      => $product_id,
+                'name'            => $product->get_name(),
+                'categories'      => $categories, 
+                'top_category'    => $category,               // array e.g. ['T-shirts', 'Summer']
+                'quantity'        => $cart_item['quantity'],
+                'price_raw'       => $product->get_price(),          // string: "29.99"
+                'price_formatted' => wc_price( $product->get_price() ), // "$29.99" or with currency
+                'price_html'      => $product->get_price_html(),     // includes <del>/<ins> if on sale
+                'line_subtotal'   => WC()->cart->get_product_subtotal( $product, $cart_item['quantity'] ),
+                'permalink'       => $product->get_permalink(),
+                'sku'          => $product->get_sku()                
+            );
+            // If it's a variation, add variation-specific info
+            if ( $product->is_type( 'variation' ) ) {
+                $item['variation_id'] = $product->get_id();
+                $item['parent_id']    = $product->get_parent_id();
+                // $item['attributes'] = $product->get_variation_attributes(); // or from $cart_item['variation']
+            }
+            $cart_contents[ $cart_item_key ] = $item;
+
+        }
+
+        if ($helloextend_enable_cart_offers === '1' && $enable_helloextend === '1' ) {
+            wp_enqueue_script('helloextend_minicart_integration_script');
+             wp_localize_script(
+                'helloextend_minicart_integration_script',
+                'ExtendCartIntegration',
+                compact('cart_contents', 'helloextend_enable_cart_offers')
+            );
+        } else {
+            HelloExtend_Protection_Logger::helloextend_log_error('Cart Offers Class / Minicart: Extend is not enabled');
+        }
+    }
+
 }

--- a/helloextend-protection/includes/class-helloextend-protection.php
+++ b/helloextend-protection/includes/class-helloextend-protection.php
@@ -249,6 +249,7 @@ class HelloExtend_Protection
         wp_register_script('helloextend_global_post_purchase_script', $this->url . '../js/helloextend-post-purchase.js', [ 'jquery', 'helloextend_script' ], '1.0.0', true);
         wp_register_script('helloextend_product_integration_script', $this->url . '../js/helloextend-pdp-offers.js', [ 'jquery', 'helloextend_global_script' ], '1.0.0', true);
         wp_register_script('helloextend_cart_integration_script', $this->url . '../js/helloextend-cart-offers.js', [ 'jquery', 'helloextend_script' ], '1.0.0', true);
+        wp_register_script('helloextend_minicart_integration_script', $this->url . '../js/helloextend-minicart-offers.js', [ 'jquery', 'helloextend_script' ], '1.0.0', true);
         wp_register_script('helloextend_shipping_integration_script', $this->url . '../js/helloextend-shipping-offers.js', [ 'jquery', 'helloextend_script' ], '1.0.0', true);
 
         $this->global_hooks = new HelloExtend_Protection_Global($this->helloextend_get_protection(), $this->get_version());

--- a/helloextend-protection/js/helloextend-minicart-offers.js
+++ b/helloextend-protection/js/helloextend-minicart-offers.js
@@ -1,0 +1,131 @@
+jQuery(document).ready(function($){
+    
+    /**
+     * Initializes minicart offers
+     * @param {Object} minicart miniCart object
+     */
+    function initMiniCartOffers(cart){
+
+        $('.woocommerce-mini-cart-item').each(function(){
+
+            const $li = $(this);  // current <li> element
+            // Find the key elements
+            const $removeLink = $li.find('a[data-cart_item_key]');
+            const $mainLink   = $li.find('a[href*="/product/"]:not(.remove_from_cart_button)');
+            const $img        = $li.find('img.attachment-woocommerce_thumbnail');
+
+            // Extract values with fallbacks
+            const cart_item_key = $removeLink.data('cart_item_key');
+
+            if(!(ExtendCartIntegration.cart_contents.hasOwnProperty(cart_item_key))){
+                return;
+            }
+
+            const productId = ExtendCartIntegration.cart_contents[cart_item_key].product_id ?? null;
+            const sku = ExtendCartIntegration.cart_contents[cart_item_key].sku;
+            const name = ExtendCartIntegration.cart_contents[cart_item_key].name;
+            const price = ExtendCartIntegration.cart_contents[cart_item_key].price_raw;
+            const quantity = ExtendCartIntegration.cart_contents[cart_item_key].quantity;
+            const category = ExtendCartIntegration.cart_contents[cart_item_key].top_category;
+            
+            const offerId = 'minicart_offer_' + productId;
+
+            
+            if ($('#' + offerId).length === 0) {
+                
+                if ( ExtendWooCommerce.warrantyAlreadyInCart(productId, cart ? cart : window.ExtendCartIntegration.cart)
+                    || ExtendCartIntegration.helloextend_enable_cart_offers !== '1') {
+                    return;
+                }
+
+                $li.append(
+                            $('<div>', {
+                                id: offerId,
+                                'data-covered': productId,
+                                'data-category': category,
+                                'data-price': price,
+                                'data-quantity': quantity,
+                                'style':'width: max-content;'
+,                                class: 'minicart-extend-offer',
+                            })
+                        );
+
+
+                    Extend.buttons.renderSimpleOffer( ('#' + offerId), {
+                        referenceId: productId,
+                        price: price,
+                        category: category,
+                        onAddToCart: ({plan, product}) => {
+                                        if (!plan || !product) {
+                                            ExtendWooCommerce.extendAjaxLog('error', 'SimpleOffer onAddToCart failed: plan or product missing');
+                                            return;
+                                        }
+                                        const data = {
+                                            quantity,
+                                            plan: {
+                                                ...plan,
+                                                covered_product_id: product.id
+                                            }
+                                        };
+                                        // Add the plan to the cart.
+                                        ExtendWooCommerce.addPlanToCart(data).then(() => {
+                                            // After adding the plan, trigger a refresh of minicart.
+     
+                                            $(document.body).trigger('wc_fragment_refresh');
+                                        });
+                                    }
+
+                                
+                    }); 
+            }
+        })
+    }
+
+    //run on page load
+    initMiniCartOffers();
+
+    //run on mini-cart updates
+    $(document.body).on('wc_fragments_loaded wc_fragments_refreshed added_to_cart removed_from_cart', function(){
+        //initMiniCartOffers();
+        ExtendWooCommerce.getCart().then(initMiniCartOffers);
+    });
+
+
+     /**
+     * Renders the cart offer for a given offer container element and params
+     * @param {HTMLElement} element Offer container element
+     * @param {object} params Offer params: referenceId, price, category
+     * @param {number} quantity Quantity of warranties to be added
+     */
+    function renderExtendOffer(element, params, quantity) {
+        
+        Extend.buttons.renderSimpleOffer(element, {
+            ...params,
+            onAddToCart: ({plan, product}) => {
+                if (!plan || !product) {
+                    ExtendWooCommerce.extendAjaxLog('error', 'SimpleOffer onAddToCart failed: plan or product missing');
+                    return;
+                }
+                
+                const data = {
+                    quantity,
+                    plan: {
+                        ...plan,
+                        covered_product_id: product.id
+                    }
+                };
+                
+                if (ExtendWooCommerce.debugLogEnabled)
+                    ExtendWooCommerce.extendAjaxLog('debug', 'SimpleOffer add to cart with data: ', JSON.stringify(data));
+                
+                // Add the plan to the cart.
+                ExtendWooCommerce.addPlanToCart(data).then(() => {
+                    // After adding the plan, enable the 'Update cart' button and trigger a click on it.
+                    $(SELECTORS.UPDATE_CART).removeAttr('disabled');
+                    $(SELECTORS.UPDATE_CART).trigger("click");
+                });
+            }
+        }); 
+    }
+
+});


### PR DESCRIPTION
minicart offers support added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warranty protection offers to the shopping cart mini-cart view, allowing customers to add extended protection plans directly from their cart preview without navigating to the full checkout page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->