### PR TITLE
Update class-helloextend-global.php

### DIFF
--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Extend Protection For WooCommerce
  * Plugin URI:        https://docs.extend.com/docs/extend-protection-plugin-for-woocommerce
  * Description:       Extend Protection for Woocommerce. Allows WooCommerce merchants to offer product and shipping protection to their customers.
- * Version:           1.2.6
+ * Version:           1.2.7
  * Author:            Extend, Inc.
  * Author URI:        https://extend.com/
  * License:           GPL-2.0+

--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -106,10 +106,20 @@ class HelloExtend_Protection_Global
         add_action('woocommerce_checkout_create_order_line_item', [$this, 'order_item_meta'], 10, 3);
 
         // update price for warranty items
-        add_action('woocommerce_before_calculate_totals', [$this, 'update_price']);
+        add_action('woocommerce_before_calculate_totals', [$this, 'update_price'], 9999);
+
+        // Stamp the plan price the moment the cart line is rehydrated from session,
+        // before any coupon/totals logic reads it. Makes the price authoritative for
+        // the whole request rather than only during woocommerce_before_calculate_totals.
+        add_filter('woocommerce_get_cart_item_from_session', [$this, 'restore_price_from_session'], 20, 2);
+
+        // Force the displayed line subtotal to reflect the plan price, so extra
+        // calculate_totals() cycles from coupon plugins can't render the $1 base.
+        add_filter('woocommerce_cart_item_subtotal', [$this, 'cart_item_subtotal'], 9999, 3);
 
         // Initialize global ExtendWooCommerce
         add_action('wp_head', [$this, 'helloextend_init_global']);
+
     }
 
     /**
@@ -322,6 +332,51 @@ class HelloExtend_Protection_Global
                  }
             }
         }
+    }
+    /**
+     * Re-apply the Extend plan price when a warranty line is restored from the
+     * session. Runs before coupon/dynamic-pricing logic reads the price, so the
+     * WC_Product carries the plan price from the very start of every request.
+     *
+     * @param array $cart_item The cart item being rebuilt from session.
+     * @param array $values    The persisted session values for this line.
+     * @return array
+     */
+    public function restore_price_from_session($cart_item, $values)
+    {
+        if (!empty($values['extendData']['price'])
+            && is_numeric($values['extendData']['price'])
+            && isset($cart_item['data'])
+            && $cart_item['data'] instanceof WC_Product
+        ) {
+            $cart_item['data']->set_price(round((float) $values['extendData']['price'] / 100, 2));
+        }
+
+        return $cart_item;
+    }
+
+    /**
+     * Force the cart/mini-cart line SUBTOTAL to reflect the Extend plan price.
+     * Mirrors cart_item_price() (which only covers the unit-price column).
+     *
+     * @param string $subtotal      Default subtotal HTML.
+     * @param array  $cart_item     Current cart item.
+     * @param string $cart_item_key Cart item key.
+     * @return string
+     */
+    public function cart_item_subtotal($subtotal, $cart_item, $cart_item_key)
+    {
+        if (!empty($cart_item['extendData'])
+            && isset($cart_item['extendData']['price'])
+            && is_numeric($cart_item['extendData']['price'])
+        ) {
+            $price    = round((float) $cart_item['extendData']['price'] / 100, 2);
+            $quantity = isset($cart_item['quantity']) ? (int) $cart_item['quantity'] : 1;
+
+            return wc_price($price * $quantity);
+        }
+
+        return $subtotal;
     }
 
     public function cart_item_price($price, $cart_item, $cart_item_key)

--- a/helloextend-protection/readme.txt
+++ b/helloextend-protection/readme.txt
@@ -5,7 +5,7 @@ Contributors: santiagoenciso33, jmbextend, alexsmithext, helloextend
 Tags: extend, protection, tracking
 Requires at least: 4.0
 Tested up to: 6.8
-Stable tag: 1.2.6
+Stable tag: 1.2.7
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ For more information on our terms of service and privacy policy, visit the links
 4. Extend's settings page in wp-admin.
 
 == Changelog ==
+= 1.2.7 2026-07-10 =
+* Fix - keep Extend plan price on cart line when Advanced Coupons is active
+
 = 1.2.6 2026-07-09 =
 ### Performance
 - **Cache the Extend Product Protection product ID.** `helloextend_product_protection_id()` previously ran an unindexed `wp_postmeta.meta_value` scan on every call, across many code paths per request. The resolved ID is now stored in an autoloaded option (`helloextend_product_protection_id`) and served from memory, with a single fully-indexed query to validate it still points to a live product.


### PR DESCRIPTION
fix: keep Extend plan price on cart line when Advanced Coupons is active

The Product Protection line reverted to its $1 base price on the cart and mini-cart whenever Advanced Coupons for WooCommerce was enabled, while checkout still showed the correct plan price.

Root cause: the plan price was applied only transiently, via set_price() during woocommerce_before_calculate_totals. Advanced Coupons forces extra calculate_totals() cycles (Add_Products / BOGO / Store Credits) and WooCommerce re-hydrates the cached cart line's product object from the session, so any render that happened outside our single hook pass fell back to the $1 base. Because it wasn't a simple ordering race on one hook, raising the hook priority did not resolve it.

Fix (includes/class-helloextend-global.php):
- Add woocommerce_get_cart_item_from_session handler (restore_price_from_session) to stamp the plan price the moment the cart line is rebuilt from session, so the WC_Product carries the correct price from the start of every request, before any coupon/totals logic reads it.
- Add woocommerce_cart_item_subtotal filter (cart_item_subtotal) so the displayed line subtotal reflects the plan price, mirroring the existing cart_item_price filter which only covered the unit-price column.
- update_price on woocommerce_before_calculate_totals is retained as a re-assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warranty and protection plan price consistency during WooCommerce cart calculations.
  * Preserved plan prices when cart items are restored from a session.
  * Updated displayed line subtotals to match the selected plan price (including quantity), even with Advanced Coupons active.
* **Chores**
  * Bumped plugin version to **1.2.7** and refreshed the changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->