### PR TITLE
1 dollar fix

### DIFF
--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Extend Protection For WooCommerce
  * Plugin URI:        https://docs.extend.com/docs/extend-protection-plugin-for-woocommerce
  * Description:       Extend Protection for Woocommerce. Allows WooCommerce merchants to offer product and shipping protection to their customers.
- * Version:           1.2.8
+ * Version:           1.2.9
  * Author:            Extend, Inc.
  * Author URI:        https://extend.com/
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if (!defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('HELLOEXTEND_PROTECTION_VERSION', '1.2.8');
+define('HELLOEXTEND_PROTECTION_VERSION', '1.2.9');
 define('HELLOEXTEND_PRODUCT_PROTECTION_SKU', 'helloextend-product-protection');
 define('HELLOEXTEND_SHIPPING_PROTECTION_SKU', 'helloextend-shipping-protection');
 

--- a/helloextend-protection/helloextend-protection.php
+++ b/helloextend-protection/helloextend-protection.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Extend Protection For WooCommerce
  * Plugin URI:        https://docs.extend.com/docs/extend-protection-plugin-for-woocommerce
  * Description:       Extend Protection for Woocommerce. Allows WooCommerce merchants to offer product and shipping protection to their customers.
- * Version:           1.2.7
+ * Version:           1.2.8
  * Author:            Extend, Inc.
  * Author URI:        https://extend.com/
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if (!defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('HELLOEXTEND_PROTECTION_VERSION', '1.2.6');
+define('HELLOEXTEND_PROTECTION_VERSION', '1.2.8');
 define('HELLOEXTEND_PRODUCT_PROTECTION_SKU', 'helloextend-product-protection');
 define('HELLOEXTEND_SHIPPING_PROTECTION_SKU', 'helloextend-shipping-protection');
 

--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -113,6 +113,21 @@ class HelloExtend_Protection_Global
         // the whole request rather than only during woocommerce_before_calculate_totals.
         add_filter('woocommerce_get_cart_item_from_session', [$this, 'restore_price_from_session'], 20, 2);
 
+        // Re-assert the plan price once the whole session cart is loaded. The block
+        // Cart/Checkout render from the Store API, which reads each line's product
+        // price directly; this guarantees the plan price is on the WC_Product for
+        // the entire request, even if a coupon plugin rehydrated the $1 base after
+        // the per-item restore above.
+        add_action('woocommerce_cart_loaded_from_session', [$this, 'apply_plan_prices_to_cart'], 20);
+
+        // Re-assert again AFTER totals are calculated. The block Cart/Checkout Store
+        // API reads each line's product price (prices.price -> get_price()) when it
+        // serializes the cart response, which happens after calculate_totals(). Extra
+        // recalc cycles (e.g. Advanced Coupons) can leave the product re-hydrated at
+        // its $1 base by then, so stamping the plan price here is what the block
+        // order summary's per-item price ends up displaying.
+        add_action('woocommerce_after_calculate_totals', [$this, 'apply_plan_prices_to_cart'], 9999);
+
         // Force the displayed line subtotal to reflect the plan price, so extra
         // calculate_totals() cycles from coupon plugins can't render the $1 base.
         add_filter('woocommerce_cart_item_subtotal', [$this, 'cart_item_subtotal'], 9999, 3);
@@ -327,9 +342,63 @@ class HelloExtend_Protection_Global
 
         if (!empty($cart_items)) {
             foreach ($cart_items as $value) {
-                if (!empty($value['extendData']) && isset($value['extendData']['price']) && is_numeric($value['extendData']['price'])) {
-                   $value['data']->set_price(round($value['extendData']['price'] / 100, 2));
+                if (!empty($value['extendData']) && isset($value['extendData']['price']) && is_numeric($value['extendData']['price'])
+                    && isset($value['data']) && $value['data'] instanceof WC_Product) {
+                    $this->stamp_plan_price($value['data'], $value['extendData']['price']);
                  }
+            }
+        }
+    }
+
+    /**
+     * Stamp the Extend plan price onto a warranty product object.
+     *
+     * Sets BOTH the active price and the regular price (and clears any sale price).
+     * The warranty product's stored base is $1/$1; setting only the active price
+     * leaves regular_price at $1, which the block Cart/Checkout Store API surfaces
+     * as prices.regular_price and can render as the visible "individual price"
+     * (a price-above-regular state). Aligning all three removes that ambiguity.
+     *
+     * @param WC_Product $product     The warranty product object on the cart line.
+     * @param int|string $price_cents The Extend plan price in cents (from extendData).
+     * @return void
+     */
+    private function stamp_plan_price($product, $price_cents)
+    {
+        $price = round((float) $price_cents / 100, 2);
+        $product->set_regular_price($price);
+        $product->set_sale_price('');
+        $product->set_price($price);
+    }
+
+    /**
+     * Re-assert the Extend plan price on every warranty line once the whole
+     * session cart has loaded. Runs before the block Cart/Checkout serialize the
+     * cart via the Store API (which reads each line's product price directly), so
+     * the plan price — not the $1 base — is what those blocks display.
+     *
+     * @param WC_Cart|mixed $cart The cart passed by the hook. Falls back to the
+     *                            global cart when the hook does not pass one.
+     * @return void
+     */
+    public function apply_plan_prices_to_cart($cart = null)
+    {
+        if (!$cart instanceof WC_Cart) {
+            $cart = (function_exists('WC') && WC()->cart instanceof WC_Cart) ? WC()->cart : null;
+        }
+
+        if (!$cart instanceof WC_Cart) {
+            return;
+        }
+
+        foreach ($cart->get_cart() as $cart_item) {
+            if (!empty($cart_item['extendData'])
+                && isset($cart_item['extendData']['price'])
+                && is_numeric($cart_item['extendData']['price'])
+                && isset($cart_item['data'])
+                && $cart_item['data'] instanceof WC_Product
+            ) {
+                $this->stamp_plan_price($cart_item['data'], $cart_item['extendData']['price']);
             }
         }
     }
@@ -349,7 +418,7 @@ class HelloExtend_Protection_Global
             && isset($cart_item['data'])
             && $cart_item['data'] instanceof WC_Product
         ) {
-            $cart_item['data']->set_price(round((float) $values['extendData']['price'] / 100, 2));
+            $this->stamp_plan_price($cart_item['data'], $values['extendData']['price']);
         }
 
         return $cart_item;
@@ -429,6 +498,23 @@ class HelloExtend_Protection_Global
     {
         if (isset($cart_item['extendData']) &&  !empty($cart_item['extendData'])) {
             $item->add_meta_data('_helloextend_data', $cart_item['extendData']);
+
+            // Force the WooCommerce order line item to carry the Extend plan price.
+            // The warranty product's base price is $1; the real plan price lives in
+            // extendData. Cart-level set_price() is transient (see update_price /
+            // restore_price_from_session) and does not reliably survive into the
+            // order under coupon plugins or the block/Store API checkout, which
+            // rebuild the line total from the $1 base. Stamping the line subtotal
+            // and total here makes the order total authoritative for BOTH classic
+            // and block checkout — this hook fires on both paths.
+            if (isset($cart_item['extendData']['price']) && is_numeric($cart_item['extendData']['price'])) {
+                $plan_price  = round((float) $cart_item['extendData']['price'] / 100, 2);
+                $quantity    = isset($cart_item['quantity']) ? (int) $cart_item['quantity'] : $item->get_quantity();
+                $line_amount = $plan_price * $quantity;
+
+                $item->set_subtotal($line_amount);
+                $item->set_total($line_amount);
+            }
 
             $covered_id = $cart_item['extendData']['covered_product_id'];
             $term       = $cart_item['extendData']['term'];

--- a/helloextend-protection/includes/class-helloextend-global.php
+++ b/helloextend-protection/includes/class-helloextend-global.php
@@ -541,7 +541,18 @@ class HelloExtend_Protection_Global
     public function checkout_details($data, $cart_item)
     {
 
-        if (!is_cart() && !is_checkout()) {
+        // is_cart()/is_checkout() are page conditionals: they are true during the
+        // initial (server-side) render of the classic and block Cart/Checkout, but
+        // FALSE on the Store API (REST) requests the block Cart/Checkout fires to
+        // refresh the cart afterwards. Without allowing the Store API context, this
+        // filter returns no item_data on that refresh and the block drops the
+        // "Product"/"Term" metadata (wc-block-components-product-metadata) a moment
+        // after load. WC()->is_rest_api_request() covers the Store API request.
+        $is_rest_request = function_exists('WC')
+            && method_exists(WC(), 'is_rest_api_request')
+            && WC()->is_rest_api_request();
+
+        if (!is_cart() && !is_checkout() && !$is_rest_request) {
             return $data;
         }
 

--- a/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
@@ -93,7 +93,7 @@ class HelloExtend_Protection_PDP_Offer
         $categories                  = get_the_terms($id, 'product_cat');
         $first_category              = HelloExtend_Protection_Global::helloextend_get_first_valid_category($categories);
 
-        $price                       = (int) ( floatval($product->get_price()) * 100 );
+        $price                       = (int) round(floatval($product->get_price()) * 100);
         $type                        = $product->get_type();
         $env                         = $this->settings['helloextend_environment'];
         $helloextend_pp_enabled      = $this->settings['enable_helloextend_pp'];

--- a/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
+++ b/helloextend-protection/includes/class-helloextend-protection-pdp-offer.php
@@ -93,7 +93,7 @@ class HelloExtend_Protection_PDP_Offer
         $categories                  = get_the_terms($id, 'product_cat');
         $first_category              = HelloExtend_Protection_Global::helloextend_get_first_valid_category($categories);
 
-        $price                       = (int) floatval($product->get_price() * 100);
+        $price                       = (int) ( floatval($product->get_price()) * 100 );
         $type                        = $product->get_type();
         $env                         = $this->settings['helloextend_environment'];
         $helloextend_pp_enabled      = $this->settings['enable_helloextend_pp'];

--- a/helloextend-protection/readme.txt
+++ b/helloextend-protection/readme.txt
@@ -5,7 +5,7 @@ Contributors: santiagoenciso33, jmbextend, alexsmithext, helloextend
 Tags: extend, protection, tracking
 Requires at least: 4.0
 Tested up to: 6.8
-Stable tag: 1.2.8
+Stable tag: 1.2.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ For more information on our terms of service and privacy policy, visit the links
 4. Extend's settings page in wp-admin.
 
 == Changelog ==
+= 1.2.9 2026-07-15 =
+* Fix - keep the warranty "Product"/Term metadata visible in the block Cart/Checkout order summary (it was dropped on the Store API cart refresh)
+
 = 1.2.8 2026-07-14 =
 * Fix - show the Extend plan price (not the $1 base) in the block-based Cart/Checkout (Store API) order summary
 * Fix - stamp the plan price on the WooCommerce order line item so placing an order no longer reverts the warranty to $1 and skews the order total

--- a/helloextend-protection/readme.txt
+++ b/helloextend-protection/readme.txt
@@ -5,7 +5,7 @@ Contributors: santiagoenciso33, jmbextend, alexsmithext, helloextend
 Tags: extend, protection, tracking
 Requires at least: 4.0
 Tested up to: 6.8
-Stable tag: 1.2.7
+Stable tag: 1.2.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,10 @@ For more information on our terms of service and privacy policy, visit the links
 4. Extend's settings page in wp-admin.
 
 == Changelog ==
+= 1.2.8 2026-07-14 =
+* Fix - show the Extend plan price (not the $1 base) in the block-based Cart/Checkout (Store API) order summary
+* Fix - stamp the plan price on the WooCommerce order line item so placing an order no longer reverts the warranty to $1 and skews the order total
+
 = 1.2.7 2026-07-10 =
 * Fix - keep Extend plan price on cart line when Advanced Coupons is active
 


### PR DESCRIPTION
metadata was disappearing upon subsequent Rest API requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved warranty product and term details in block-based Cart and Checkout order summaries after Store API refreshes.

* **Bug Fixes**
  * Fixed missing warranty metadata during cart and checkout updates.

* **Chores**
  * Updated the plugin version to 1.2.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->